### PR TITLE
Update .env.example to use VITE_ prefixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@
 # Copy this file to .env and replace with your actual credentials
 
 # Your Mural API key (required)
-MURAL_API_KEY=your_mural_api_key_here
-MURAL_API_URL=https://api-staging.muralpay.com
+VITE_MURAL_API_KEY=your_mural_api_key_here
+VITE_MURAL_API_URL=https://api-staging.muralpay.com


### PR DESCRIPTION
Fixes the .env.example which was missing VITE_ before the var names